### PR TITLE
Allow profiling examples

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -205,7 +205,7 @@ pub fn compile(release: bool, target: &CargoTarget) -> Result<Vec<BinFile>, Erro
         .with_context(|| format!("Couldn't get cargo's exit status\n{}", cmd_str))?;
 
     if binaries.is_empty() {
-        bail!("cargo did not produced any useful binary\n{}", cmd_str)
+        bail!("cargo did not produce any useful binary\n{}", cmd_str)
     }
 
     binaries.sort_by_key(|b| b.path.clone());

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -155,6 +155,7 @@ pub fn compile(release: bool, target: &CargoTarget) -> Result<Vec<BinFile>, Erro
                 if artifact.target.kind.contains(&"bin".to_string())
                     || artifact.target.kind.contains(&"test".to_string())
                     || artifact.target.kind.contains(&"bench".to_string())
+                    || artifact.target.kind.contains(&"example".to_string())
                 {
                     let mut executable = None;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), Error> {
     match cmd {
         SubCommand::All => {}
         SubCommand::Flamegraph(cmd) => {
-            cmd.run().context("faield to create flamegraph")?;
+            cmd.run().context("failed to create flamegraph")?;
         }
 
         SubCommand::BinPath { target, release } => {


### PR DESCRIPTION
    $ cargo profile flamegraph --root example throughput
        Finished dev [unoptimized + debuginfo] target(s) in 0.12s
    Error: faield to create flamegraph

    Caused by:
        0: cargo execution failed
        1: cargo did not produced any useful binary
           "/Users/odin/.rustup/toolchains/stable-x86_64-apple-darwin/bin/cargo" "build" "--example" "throughput" "--message-format=json"

And a couple of related error typos.